### PR TITLE
\octave, 6 in the line 122 does not work

### DIFF
--- a/src/beginner/src/ch02-03-chords.md
+++ b/src/beginner/src/ch02-03-chords.md
@@ -114,14 +114,13 @@ var a = [60, 60, 67, 67, 69, 69, 67, 65, 65, 64, 64, 62, 62, 60];
 var b = [67, 67, 65, 65, 64, 64, 62];
 
 var prog = Pbind(
-  \octave, 5,
-  \degree, progA ++ progB ++ progB,
-  \dur, Pseq([4, Pseq([2], 14), 4, Pseq([2], 6)]));
+	\octave, 5,
+	\degree, progA ++ progB ++ progB,
+	\dur, Pseq([4, Pseq([2], 14), 4, Pseq([2], 6)]));
 
 var melody = Pbind(
-  \octave, 6,
-  \midinote, Pseq(a) ++ Pseq(b, 2) ++ Pseq(a),
-  \dur, Pseq([1, 1, 1, 1, 1, 1, 2], 6),
+	\midinote, (Pseq(a) ++ Pseq(b, 2) ++ Pseq(a)) + 12,
+	\dur, Pseq([1, 1, 1, 1, 1, 1, 2], 6),
 );
 
 Ppar([melody, prog]).play


### PR DESCRIPTION
The variable melody uses midonote. Thus, \octave does not work.
If you want to show the usages of \octave, then you must change variable a and variable b. Considering the examples in the earlier chapter, the following code block might be appropriate.
```
(
var c = [0, 2, 4];  // C E G
var f = [0, 3, 5];  // C F A
var g7 = [-1, 1, 3, 4]; // B D F G

var progA = Pseq([c, f, c, f, c, g7, c]);
var progB = Pseq([c, f, c, g7, c, f, c, g7]);

var a = Pseq([0, 0, 4, 4, 5, 5, 4, 3, 3, 2, 2, 1, 1, 0]);
var b = Pseq([4, 4, 3, 3, 2, 2, 1]);

var prog = Pbind(
	\octave, 5,
	\degree, progA ++ progB ++ progB,
	\dur, Pseq([4, Pseq([2], 14), 4, Pseq([2], 6)]));

var melody = Pbind(
	\octave, 6,
	\degree, a ++ b ++ b ++ a,
	\dur, Pseq([1, 1, 1, 1, 1, 1, 2], 6));

Ppar([melody, prog]).play
)
```
If you want to use midinote then the keyword \octave must be got rid of, and 12 must be added as shown in my suggestion.