### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,34 @@
+name: "CI"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-book:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout repository
+
+      - name: Install mdbook
+        run: |
+          mkdir bin
+          wget https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz
+          tar xf mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz --directory=bin
+          echo "${{github.workspace}}/bin" >> ${GITHUB_PATH}
+          # not yet in PATH due to missing source command
+          bin/mdbook --version
+
+      - name: Build book
+        run: |
+          make all
+
+      - name: publish book
+        uses: peaceiris/actions-gh-pages@v4.0.0
+        if: success() && github.ref == 'refs/heads/main' # only deploy main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: books

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
 books
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 books
+bin/
+*.tar.gz
 
 # General
 .DS_Store
@@ -6,7 +8,8 @@ books
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+all: meta beginner cookbook intermediate synthesis
+
+beginner:
+	mdbook build src/beginner
+
+cookbook:
+	mdbook build src/cookbook
+
+intermediate:
+	mdbook build src/intermediate
+
+synthesis:
+	mdbook build src/synthesis
+
+meta:
+	mkdir -p books
+	cp combined-index.html books/index.html
+
+clean:
+	rm -rf books

--- a/combined-index.html
+++ b/combined-index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html lang="en" class="light" dir="ltr">
+    <head>
+        <meta charset="UTF-8">
+        <title>SuperCollider Books</title>
+
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="theme-color" content="#ffffff">
+
+    </head>
+    <body class="sidebar-visible no-js">
+        <h1>SuperCollider books</h1>
+        <ul>
+            <li><a href="beginner/index.html">Beginner</a></li>
+            <li><a href="cookbook/index.html">Cookbook</a></li>
+            <li><a href="intermediate/index.html">Intermediate</a></li>
+            <li><a href="synthesis/index.html">Synthesis</a></li>
+        </ul>
+    </body>
+</html>


### PR DESCRIPTION
I don't know the actual state of this project and just came across it randomly while I searched for another repo, yet I really like the idea of providing a space to create learning tutorials.

Though there is this question why this should not be part of the SuperCollider documentation, but yet I would find such a website much more beginner friendly than the provided docs and it could be developed outside of the normal SC release cycles.

To give this a "restart" I added a CI to this so this would get deployed via GH pages, e.g. https://capital-g.github.io/learn/
Would be great if someone would continue on this :)

Edit: If this is *dead* instead, we should archive it.